### PR TITLE
fix: jbang workarounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 org
 java-gen.sh
 
+src
+Main.jar

--- a/Main.jsh
+++ b/Main.jsh
@@ -4,10 +4,3 @@
 //DEPS org.projectlombok:lombok:1.18.24
 //DEPS io.sundr:builder-annotations:0.90.4
 //DEPS javax.validation:validation-api:2.0.1.Final
-//SOURCES src/**.java
-public class Main {
-
-    public static void main(String... args) {
-        System.out.println("Hello");
-    }
-}

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,9 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "k8gen": {
+      "script-ref": "https://oss.sonatype.org/content/repositories/snapshots/io/fabric8/java-generator-cli/6.0-SNAPSHOT/java-generator-cli-6.0-20220207.143845-1.jar"
+    }
+  },
+  "templates": {}
+}

--- a/test.sh
+++ b/test.sh
@@ -1,21 +1,18 @@
 #! /bin/bash
 set -x
 
-# download java-gen
-# wget https://oss.sonatype.org/content/repositories/snapshots/io/fabric8/java-generator-cli/6.0-SNAPSHOT/java-generator-cli-6.0-20220426.024241-81.sh
-# mv java-generator-cli-6.0-20220426.024241-81.sh java-gen.sh
-# chmod a+x java-gen.sh
-
 
 # # Get the Keycloak CRD
 # wget https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/main/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
 
-# # Run java-gen
-# ./java-gen.sh -add-extra-annotations=true --source=keycloaks.k8s.keycloak.org-v1.yml --target=${PWD}
+# Run java-gen via alias k8gen in .jbang-catalog.json
+mkdir src
+jbang k8gen --add-extra-annotations=true --source=keycloaks.k8s.keycloak.org-v1.yml --target=${PWD}
 
-# # Run Jbang
-all_java_files=$(find ${PWD} -type f -name "*.java" | tr '\n' ' ')
+# build a jar out of src/**.java included in Main.java + dependencies
+jbang export local Main.java
 
-# Doesn't work:
-jbang --fresh --deps="io.fabric8:kubernetes-client:6.0-SNAPSHOT,io.sundr:builder-annotations:0.90.4,org.projectlombok:lombok:1.18.24" io.sundr:builder-annotations:0.90.4 --insecure --interactive ${all_java_files%?}
+# run Main.jsh
+jbang --class-path Main.jar -i Main.jsh
+
 


### PR DESCRIPTION
jbang (for now) doesn't like `jbang build --sources=**.java` so have to add an intermediate step of exporting.
